### PR TITLE
'prefix' parameter : Prefixes extracted keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ $ gem install fluent-plugin-split
 |key_name| key name to be split | |
 |out_key| key name of json object which includes divided records | nil |
 |reserve_msg| if original message is reserved or not | nil |
+|keys_prefix| if set, all extracted keys names will be preceded by this string | nil |

--- a/lib/fluent/plugin/out_split.rb
+++ b/lib/fluent/plugin/out_split.rb
@@ -9,7 +9,7 @@ module Fluent
     config_param :key_name, :string
     config_param :out_key, :string, :default => nil
     config_param :reserve_msg, :bool, :default => nil
-    config_param :prefix, :string, :default => nil
+    config_param :keys_prefix, :string, :default => nil
 
     def configure(conf)
       super
@@ -20,7 +20,7 @@ module Fluent
       end
 
       @sep_regex = Regexp.new(@separator)
-      if (!prefix.nil? && prefix.is_a?(String))
+      if (!keys_prefix.nil? && keys_prefix.is_a?(String))
         @store_fun = method(:store_with_prefix)
       else
         @store_fun = method(:store)
@@ -60,7 +60,7 @@ module Fluent
     end
 
     def store_with_prefix(data, key, value)
-      data.store(@prefix+key, value)
+      data.store(@keys_prefix+key, value)
     end
 
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,13 +1,13 @@
 require 'rubygems'
 require 'bundler'
-begin
-  Bundler.setup(:default, :development)
-rescue Bundler::BundlerError => e
-  $stderr.puts e.message
-  $stderr.puts "Run `bundle install` to install missing gems"
-  exit e.status_code
-end
 require 'test/unit'
+#begin
+#  Bundler.setup(:default, :development)
+#rescue Bundler::BundlerError => e
+#  $stderr.puts e.message
+#  $stderr.puts "Run `bundle install` to install missing gems"
+#  exit e.status_code
+#end
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,13 +1,13 @@
 require 'rubygems'
 require 'bundler'
+begin
+  Bundler.setup(:default, :development)
+rescue Bundler::BundlerError => e
+  $stderr.puts e.message
+  $stderr.puts "Run `bundle install` to install missing gems"
+  exit e.status_code
+end
 require 'test/unit'
-#begin
-#  Bundler.setup(:default, :development)
-#rescue Bundler::BundlerError => e
-#  $stderr.puts e.message
-#  $stderr.puts "Run `bundle install` to install missing gems"
-#  exit e.status_code
-#end
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))

--- a/test/plugin/test_out_split.rb
+++ b/test/plugin/test_out_split.rb
@@ -90,4 +90,19 @@ class SplitOutputTest < Test::Unit::TestCase
       {"data" => {"key1" => "val1", "key2" => "val2"}},
     ], d.records
   end
+
+  def test_format_prefix
+    d = create_driver(CONFIG + %[
+      out_key data
+      prefix extracted_
+    ])
+
+    d.run do
+      d.emit({"message" => "key1=val1 key2=val2"})
+    end
+
+    assert_equal [
+      {"data" => {"extracted_key1" => "val1", "extracted_key2" => "val2"}},
+    ], d.records
+  end
 end

--- a/test/plugin/test_out_split.rb
+++ b/test/plugin/test_out_split.rb
@@ -91,10 +91,10 @@ class SplitOutputTest < Test::Unit::TestCase
     ], d.records
   end
 
-  def test_format_prefix
+  def test_format_keysprefix
     d = create_driver(CONFIG + %[
       out_key data
-      prefix extracted_
+      keys_prefix extracted_
     ])
 
     d.run do


### PR DESCRIPTION
In some cases, extracted keys could conflict with existing keys in the JSON structure.
One solution is to output extracted keys in "out_field", but I need to use another plugin to flatten the JSON.
This little change allows to prefix each extracted field keys with defined string.

In my case "time" parameter was overloaded. This fixes my problem. Merge if you want.
